### PR TITLE
remove direct dependency on Test::Portability::Files

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -15,9 +15,6 @@ Test::MinimumVersion.max_target_perl = 5.008003
 -remove = Test::CPAN::Meta
 -remove = MetaTests
 
-[Prereqs]
-Test::Portability::Files = 0
-
 [Deprecated]
 module = Dist::Zilla::Plugin::PortabilityTests
 


### PR DESCRIPTION
This dist doesn't use Test::Portability::Files directly, but instead it generates a test that uses it. Listing it as a prerequisite means making a build of a dist using this plugin needs to install the module even though it is never used. The test module is injected as a develop prereq, and those should be installed before trying to run author tests.