### PR TITLE
re-add Test::Portability::Files as test dependency

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -14,6 +14,9 @@ authority = cpan:DOHERTY
 Test::MinimumVersion.max_target_perl = 5.008003
 -remove = MetaTests
 
+[Prereqs / TestRequires]
+Test::Portability::Files = 0
+
 [Deprecated]
 module = Dist::Zilla::Plugin::PortabilityTests
 


### PR DESCRIPTION
Oops. I missed the the test that was using the module. Listing Test::Portability::Files as a test dependency still accomplishes the same thing, as they can be omitted by skipping tests.